### PR TITLE
Fix api call return value.

### DIFF
--- a/src/Controller/Component/RecaptchaComponent.php
+++ b/src/Controller/Component/RecaptchaComponent.php
@@ -64,6 +64,7 @@ class RecaptchaComponent extends Component
      * Call reCAPTCHA API to verify
      *
      * @return string
+     * @codeCoverageIgnore
      */
     protected function apiCall()
     {

--- a/src/Controller/Component/RecaptchaComponent.php
+++ b/src/Controller/Component/RecaptchaComponent.php
@@ -63,7 +63,7 @@ class RecaptchaComponent extends Component
     /**
      * Call reCAPTCHA API to verify
      *
-     * @return \Cake\Http\Client\Response
+     * @return string
      */
     protected function apiCall()
     {
@@ -73,6 +73,6 @@ class RecaptchaComponent extends Component
             'secret' => $this->_config['secret'],
             'response' => $controller->request->data['g-recaptcha-response'],
             'remoteip' => $controller->request->clientIp()
-        ]);
+        ])->getBody();
     }
 }


### PR DESCRIPTION
I had made a mistake in previous PR. `apiCall()` needs to return string instead of the response object.