### PR TITLE
Adds data-size attribute in g-recaptcha, with its value set in display method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,15 +64,6 @@ Display recaptcha in your view:
     <?= $this->Form->end()?>
 ```
 
-Display the compact recaptcha in your view:
-```
-    <?= $this->Form->create()?>
-    <?= $this->Form->input('email')?>
-    <?= $this->Recaptcha->display(true)?>  // Display the compact size recaptcha box in your view, if display first parameter = true. Else, defaults to normal size
-    <?= $this->Form->submit()?>
-    <?= $this->Form->end()?>
-```
-
 Verify in your controller function
 ```
     public function forgotPassword() {

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ $this->loadComponent('Recaptcha.Recaptcha', [
     'type' => 'image',  // image/audio
     'theme' => 'light', // light/dark
     'lang' => 'vi',      // default en
+    'size' => 'normal'  // normal/compact
 ]);
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ Display recaptcha in your view:
     <?= $this->Form->end()?>
 ```
 
+Display the compact recaptcha in your view:
+```
+    <?= $this->Form->create()?>
+    <?= $this->Form->input('email')?>
+    <?= $this->Recaptcha->display(true)?>  // Display the compact size recaptcha box in your view, if display first parameter = true. Else, defaults to normal size
+    <?= $this->Form->submit()?>
+    <?= $this->Form->end()?>
+```
+
 Verify in your controller function
 ```
     public function forgotPassword() {

--- a/src/Controller/Component/RecaptchaComponent.php
+++ b/src/Controller/Component/RecaptchaComponent.php
@@ -24,7 +24,8 @@ class RecaptchaComponent extends Component
         'theme' => 'light',
         'type' => 'image',
         'enable' => true,
-        'lang' => 'en'
+        'lang' => 'en',
+        'size' => 'normal',
     ];
 
     /**

--- a/src/Template/Element/recaptcha.ctp
+++ b/src/Template/Element/recaptcha.ctp
@@ -4,6 +4,7 @@
     data-sitekey="<?= $recaptcha['sitekey'] ?>"
     data-theme="<?= $recaptcha['theme'] ?>"
     data-type="<?= $recaptcha['type'] ?>"
+    data-size="<?= $recaptchaSize ?>"
     async defer>
 </div>
 <noscript>

--- a/src/Template/Element/recaptcha.ctp
+++ b/src/Template/Element/recaptcha.ctp
@@ -4,7 +4,6 @@
     data-sitekey="<?= $recaptcha['sitekey'] ?>"
     data-theme="<?= $recaptcha['theme'] ?>"
     data-type="<?= $recaptcha['type'] ?>"
-    data-size="<?= $recaptchaSize ?>"
     async defer>
 </div>
 <noscript>

--- a/src/Template/Element/recaptcha.ctp
+++ b/src/Template/Element/recaptcha.ctp
@@ -4,6 +4,7 @@
     data-sitekey="<?= $recaptcha['sitekey'] ?>"
     data-theme="<?= $recaptcha['theme'] ?>"
     data-type="<?= $recaptcha['type'] ?>"
+    data-size="<?= $recaptcha['size'] ?>"
     async defer>
 </div>
 <noscript>

--- a/src/View/Helper/RecaptchaHelper.php
+++ b/src/View/Helper/RecaptchaHelper.php
@@ -21,20 +21,13 @@ class RecaptchaHelper extends Helper
 
     /**
      * Display recaptcha function
-     * @param bool $compactSize Show compact size recaptcha if true. Defaults to false.
      * @return string
      */
-    public function display($compactSize = false)
+    public function display()
     {
         $recaptcha = $this->config();
         if (!$recaptcha['enable']) {
             return '';
-        }
-
-        if ($compactSize == true) {
-            $recaptchaSize = 'compact';
-        } else {
-            $recaptchaSize = 'normal'; // set recaptcha size as normal (default value)
         }
 
         return $this->_View->element('Recaptcha.recaptcha', compact('recaptcha'));

--- a/src/View/Helper/RecaptchaHelper.php
+++ b/src/View/Helper/RecaptchaHelper.php
@@ -21,13 +21,20 @@ class RecaptchaHelper extends Helper
 
     /**
      * Display recaptcha function
+     * @param bool $compactSize Show compact size recaptcha if true. Defaults to false.
      * @return string
      */
-    public function display()
+    public function display($compactSize = false)
     {
         $recaptcha = $this->config();
         if (!$recaptcha['enable']) {
             return '';
+        }
+
+        if ($compactSize == true) {
+            $recaptchaSize = 'compact';
+        } else {
+            $recaptchaSize = 'normal'; // set recaptcha size as normal (default value)
         }
 
         return $this->_View->element('Recaptcha.recaptcha', compact('recaptcha'));

--- a/tests/TestCase/View/Helper/RecaptchaHelperTest.php
+++ b/tests/TestCase/View/Helper/RecaptchaHelperTest.php
@@ -24,6 +24,7 @@ class RecaptchaHelperTest extends TestCase
                 'theme' => 'theme',
                 'type' => 'type',
                 'lang' => 'lang',
+                'size' => 'size',
             ]
         );
     }


### PR DESCRIPTION
Issue #4 

This adds a parameter in display method call. When setted to true, the recaptcha box will be displayed with compact size. Else, the recaptcha box will be displayed with normal size, which is the default size.