### PR TITLE
fixed for CakePHP 4

### DIFF
--- a/src/Controller/Component/RecaptchaComponent.php
+++ b/src/Controller/Component/RecaptchaComponent.php
@@ -74,8 +74,8 @@ class RecaptchaComponent extends Component
 
         return $client->post('https://www.google.com/recaptcha/api/siteverify', [
             'secret' => $this->_config['secret'],
-            'response' => $controller->request->getData('g-recaptcha-response'),
-            'remoteip' => $controller->request->clientIp()
+            'response' => $controller->getRequest()->getData('g-recaptcha-response'),
+            'remoteip' => $controller->getRequest()->clientIp()
         ])->getBody();
     }
 }


### PR DESCRIPTION
Another fix for CakePHP.
It would probably be appropriate for the tests to also cover the `apiCall()` method.